### PR TITLE
Settings default_auto_field for the app

### DIFF
--- a/botmanager/apps.py
+++ b/botmanager/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 
 class BotManagerConfig(AppConfig):
     name = 'botmanager'
+    default_auto_field = 'django.db.models.BigAutoField'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-botmanager',
-    version='0.2.21',
+    version='0.2.22',
     description='Async tasks for django',
     author='Dimoha',
     author_email='dimoha@controlstyle.ru',


### PR DESCRIPTION
Сейчас в 0011 миграции для id используется BigAutoField, если в настройках проекта используется другое, например, AutoField, то джанга видит разницу в поле и хочет сделать миграцию
![image](https://github.com/user-attachments/assets/b2b429e3-7f02-4c9e-b509-668a89bfe51d)
